### PR TITLE
chore: bump dremio minio dep

### DIFF
--- a/bitnami/dremio/Chart.yaml
+++ b/bitnami/dremio/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
 - condition: minio.enabled
   name: minio
   repository: oci://ghcr.io/defenseunicorns/bitferno
-  version: 14.x.x
+  version: 17.x.x
 - condition: zookeeper.enabled
   name: zookeeper
   repository: oci://ghcr.io/defenseunicorns/bitferno


### PR DESCRIPTION
- Update minio dep on dremio chart, which was causing CI failures.